### PR TITLE
DP-134 Handle Empty Description

### DIFF
--- a/KinEcosystem/ViewModel/OrderViewModel.swift
+++ b/KinEcosystem/ViewModel/OrderViewModel.swift
@@ -47,7 +47,11 @@ class OrderViewModel {
                 details.attributed(14.0, weight: .regular, color: detailsColor)
         var subtitleString = model.description_
         if let shortDate = Iso8601DateFormatter.shortString(from: model.completion_date as Date) {
-            subtitleString = subtitleString + " - " + shortDate
+            if (subtitleString.isEmpty){
+              subtitleString = shortDate
+            } else{
+                subtitleString = subtitleString + " - " + shortDate
+            }
         }
         
         subtitle = subtitleString.attributed(14.0, weight: .regular, color: .kinBlueGreyTwo)


### PR DESCRIPTION
* Main purpose:
It's not possible to create an empty description in order from iOS (as it's strictly expected to have a description), the server will return empty desc from now on and iOS can handle it.
* Technical description:
Handle the case of empty description in order subtitle, display only date when there's no description 
* Dilemmas you faced with?
* Tests
Tested manually against local marketplace server
* Documentation (Source/readme.md)