### PR TITLE
fixes in orders flow - payment watching and updating balance

### DIFF
--- a/KinEcosystem/Promises/Flows.swift
+++ b/KinEcosystem/Promises/Flows.swift
@@ -31,7 +31,7 @@ typealias POFlowPromise = KinUtil.Promise<(PaymentMemoIdentifier, OpenOrder)>
 
 @available(iOS 9.0, *)
 struct Flows {
-        
+    
     static func earn(offerId: String,
                      resultPromise: Promise<String>,
                      core: Core) {
@@ -77,50 +77,57 @@ struct Flows {
             }.then { memo, order -> Promise<(PaymentMemoIdentifier, OpenOrder)> in
                 return core.data.changeObjects(of: Offer.self,
                                                changeBlock: { _, offers in
-                    offers.first?.pending = true
+                                                offers.first?.pending = true
                 }, with: NSPredicate(with:["id": offerId]))
                     .then {
                         KinUtil.Promise<(PaymentMemoIdentifier, OpenOrder)>().signal((memo, order))
                 }
             }.then { memo, order -> KinUtil.Promise<(PaymentMemoIdentifier, OpenOrder)> in
-                return core.blockchain.waitForNewPayment(with: memo)
+                let p = POFlowPromise()
+                core.blockchain.waitForNewPayment(with: memo, timeout: 15.0)
                     .then { txHash in
                         Kin.track { try EarnOrderPaymentConfirmed(orderID: order.id, transactionID: txHash) }
-                        return KinUtil.Promise<(PaymentMemoIdentifier, OpenOrder)>().signal((memo, order))
+                    } .error({ (_) in
+                        //in case of timeout, relay on server order verfication
+                        logVerbose("waitForNewPayment timeout, waiting for order confirmation.")
+                    })
+                    .finally {
+                        p.signal((memo, order))
                 }
+                return p
             }.then { memo, order -> KinUtil.Promise<OpenOrder> in
                 core.blockchain.stopWatchingForNewPayments(with: memo)
                 let intervals: [TimeInterval] = [2, 4, 8, 16, 32, 32, 32, 32]
                 return attempt(retryIntervals: intervals,
                                closure: { attemptNumber -> Promise<Void> in
-                    let p = KinUtil.Promise<Void>()
-                    logVerbose("attempt to get earn order with !pending state: (\(attemptNumber)/\(intervals.count + 1))")
-                    var pending = true
-                    core.network.dataAtPath("orders/\(order.id)")
-                        .then { data in
-                            core.data.read(Order.self, with: data,
-                                           readBlock: { networkOrder in
-                                logVerbose("earn order \(networkOrder.id) status: \(networkOrder.orderStatus)")
-                                if networkOrder.orderStatus != .pending {
-                                    pending = false
-                                }
-                            }).then {
-                                if pending {
-                                    if attemptNumber == 5 || attemptNumber == intervals.count + 1 {
-                                        logWarn("attempts reached \(attemptNumber)")
-                                        _ = core.data.changeObjects(of: Order.self, changeBlock: { _, orders in
-                                            if let order = orders.first {
-                                                order.orderStatus = attemptNumber == 5 ? .delayed : .failed
+                                let p = KinUtil.Promise<Void>()
+                                logVerbose("attempt to get earn order with !pending state: (\(attemptNumber)/\(intervals.count + 1))")
+                                var pending = true
+                                core.network.dataAtPath("orders/\(order.id)")
+                                    .then { data in
+                                        core.data.read(Order.self, with: data,
+                                                       readBlock: { networkOrder in
+                                                        logVerbose("earn order \(networkOrder.id) status: \(networkOrder.orderStatus)")
+                                                        if networkOrder.orderStatus != .pending {
+                                                            pending = false
+                                                        }
+                                        }).then {
+                                            if pending {
+                                                if attemptNumber == 5 || attemptNumber == intervals.count + 1 {
+                                                    logWarn("attempts reached \(attemptNumber)")
+                                                    _ = core.data.changeObjects(of: Order.self, changeBlock: { _, orders in
+                                                        if let order = orders.first {
+                                                            order.orderStatus = attemptNumber == 5 ? .delayed : .failed
+                                                        }
+                                                    }, with: NSPredicate(with: ["id":order.id]))
+                                                }
+                                                p.signal(OrderStatusError.orderStillPending)
+                                            } else {
+                                                p.signal(())
                                             }
-                                        }, with: NSPredicate(with: ["id":order.id]))
-                                    }
-                                    p.signal(OrderStatusError.orderStillPending)
-                                } else {
-                                    p.signal(())
+                                        }
                                 }
-                            }
-                    }
-                    return p
+                                return p
                 }).then {
                     KinUtil.Promise<OpenOrder>().signal(order)
                 }
@@ -129,6 +136,8 @@ struct Flows {
                     guard let offer = result.first else {
                         return
                     }
+                    //update balance after order completed
+                    _ = core.blockchain.balance()
                     if let type = KBITypes.OfferType(rawValue: offer.offerContentType.rawValue) {
                         Kin.track { try EarnOrderCompleted(kinAmount: Double(order.amount), offerID: order.offer_id, offerType: type, orderID: order.id) }
                     }
@@ -170,10 +179,10 @@ struct Flows {
                         if let order = openOrder {
                             _ = core.data.changeObjects(of: Order.self,
                                                         changeBlock: { _, orders in
-                                if let  completedOrder = orders.first,
-                                    completedOrder.orderStatus != .failed {
-                                    completedOrder.orderStatus = .completed
-                                }
+                                                            if let  completedOrder = orders.first,
+                                                                completedOrder.orderStatus != .failed {
+                                                                completedOrder.orderStatus = .completed
+                                                            }
                             }, with: NSPredicate(with: ["id": order.id]))
                         }
                         openOrder = nil
@@ -249,10 +258,10 @@ struct Flows {
             }.then { recipient, amount, order, memo -> SDOPFlowPromise in
                 return core.data.changeObjects(of: Offer.self,
                                                changeBlock: { _, offers in
-                    if let offer = offers.first {
-                        offer.pending = true
-                        logVerbose("changed offer \(offer.id) status to pending")
-                    }
+                                                if let offer = offers.first {
+                                                    offer.pending = true
+                                                    logVerbose("changed offer \(offer.id) status to pending")
+                                                }
                 }, with: NSPredicate(with: ["id" : offerId]))
                     .then {
                         SDOPFlowPromise().signal((recipient, amount, order, memo))
@@ -267,47 +276,43 @@ struct Flows {
                         logVerbose("\(amount) kin sent to \(recipient)")
                         return KinUtil.Promise<(PaymentMemoIdentifier, OpenOrder)>().signal((memo, order))
                 }
-            }.then { memo, order -> KinUtil.Promise<(PaymentMemoIdentifier, OpenOrder)> in
-                return core.blockchain.waitForNewPayment(with: memo)
-                    .then { txHash in
-                        return POFlowPromise().signal((memo, order))
-                }
             }.then { memo, order -> KinUtil.Promise<OpenOrder> in
+                _ = core.blockchain.balance();
                 core.blockchain.stopWatchingForNewPayments(with: memo)
                 let intervals: [TimeInterval] = [2, 4, 8, 16, 32, 32, 32, 32]
                 return attempt(retryIntervals: intervals,
                                closure: { attemptNumber -> Promise<Void> in
-                    let p = KinUtil.Promise<Void>()
-                    logVerbose("attempt to get spend order with !pending state (and result): (\(attemptNumber)/\(intervals.count + 1))")
-                    var pending = true
-                    core.network.dataAtPath("orders/\(order.id)")
-                        .then { data in
-                            core.data.read(Order.self,
-                                           with: data,
-                                           readBlock: { networkOrder in
-                                let hasResult = (networkOrder.result as? CouponCode)?.coupon_code != nil
-                                logVerbose("spend order \(networkOrder.id) status: \(networkOrder.orderStatus), result: \(hasResult ? "👍🏼" : "nil")")
-                                if (networkOrder.orderStatus != .pending && hasResult) || networkOrder.orderStatus == .failed {
-                                    pending = false
-                                }
-                            }).then {
-                                if pending {
-                                    if attemptNumber == 5 || attemptNumber == intervals.count + 1 {
-                                        logWarn("attempts reached \(attemptNumber)")
-                                        _ = core.data.changeObjects(of: Order.self,
-                                                                    changeBlock: { _, orders in
-                                            if let order = orders.first {
-                                                order.orderStatus = attemptNumber == 5 ? .delayed : .failed
+                                let p = KinUtil.Promise<Void>()
+                                logVerbose("attempt to get spend order with !pending state (and result): (\(attemptNumber)/\(intervals.count + 1))")
+                                var pending = true
+                                core.network.dataAtPath("orders/\(order.id)")
+                                    .then { data in
+                                        core.data.read(Order.self,
+                                                       with: data,
+                                                       readBlock: { networkOrder in
+                                                        let hasResult = (networkOrder.result as? CouponCode)?.coupon_code != nil
+                                                        logVerbose("spend order \(networkOrder.id) status: \(networkOrder.orderStatus), result: \(hasResult ? "👍🏼" : "nil")")
+                                                        if (networkOrder.orderStatus != .pending && hasResult) || networkOrder.orderStatus == .failed {
+                                                            pending = false
+                                                        }
+                                        }).then {
+                                            if pending {
+                                                if attemptNumber == 5 || attemptNumber == intervals.count + 1 {
+                                                    logWarn("attempts reached \(attemptNumber)")
+                                                    _ = core.data.changeObjects(of: Order.self,
+                                                                                changeBlock: { _, orders in
+                                                                                    if let order = orders.first {
+                                                                                        order.orderStatus = attemptNumber == 5 ? .delayed : .failed
+                                                                                    }
+                                                    }, with: NSPredicate(with: ["id":order.id]))
+                                                }
+                                                p.signal(OrderStatusError.orderStillPending)
+                                            } else {
+                                                p.signal(())
                                             }
-                                        }, with: NSPredicate(with: ["id":order.id]))
-                                    }
-                                    p.signal(OrderStatusError.orderStillPending)
-                                } else {
-                                    p.signal(())
+                                        }
                                 }
-                            }
-                    }
-                    return p
+                                return p
                 }).then {
                     KinUtil.Promise<OpenOrder>().signal(order)
                 }
@@ -369,13 +374,13 @@ struct Flows {
                         if let order = openOrder {
                             _ = core.data.changeObjects(of: Order.self,
                                                         changeBlock: { _, orders in
-                                if let  completedOrder = orders.first,
-                                    completedOrder.orderStatus != .failed {
-                                    completedOrder.orderStatus = .completed
-                                    if let p = successPromise {
-                                        p.signal(completedOrder.id)
-                                    }
-                                }
+                                                            if let  completedOrder = orders.first,
+                                                                completedOrder.orderStatus != .failed {
+                                                                completedOrder.orderStatus = .completed
+                                                                if let p = successPromise {
+                                                                    p.signal(completedOrder.id)
+                                                                }
+                                                            }
                             }, with: NSPredicate(with: ["id": order.id]))
                         }
                         openOrder = nil
@@ -431,7 +436,6 @@ struct Flows {
                 }
                 let memo = PaymentMemoIdentifier(appId: appId,
                                                  id: order.id)
-                try core.blockchain.startWatchingForNewPayments(with: memo)
                 return core.network.dataAtPath("orders/\(order.id)", method: .post)
                     .then { data in
                         Kin.track { try SpendOrderCompletionSubmitted(isNative: true, offerID: order.offer_id, orderID: order.id) }
@@ -444,10 +448,10 @@ struct Flows {
             }.then { recipient, amount, order, memo -> SDOPFlowPromise in
                 return core.data.changeObjects(of: Offer.self,
                                                changeBlock: { _, offers in
-                    if let offer = offers.first {
-                        offer.pending = true
-                        logVerbose("changed offer \(offer.id) status to pending")
-                    }
+                                                if let offer = offers.first {
+                                                    offer.pending = true
+                                                    logVerbose("changed offer \(offer.id) status to pending")
+                                                }
                 }, with: NSPredicate(with: ["id" : order.offer_id]))
                     .then {
                         SDOPFlowPromise().signal((recipient, amount, order, memo))
@@ -462,48 +466,43 @@ struct Flows {
                         logVerbose("\(amount) kin sent to \(recipient)")
                         return POFlowPromise().signal((memo, order))
                 }
-            }.then { memo, order -> POFlowPromise in
-                return core.blockchain.waitForNewPayment(with: memo)
-                    .then { txHash in
-                        POFlowPromise().signal((memo, order))
-                }
             }.then { memo, order -> KinUtil.Promise<OpenOrder> in
-                core.blockchain.stopWatchingForNewPayments(with: memo)
+                _ = core.blockchain.balance();
                 let intervals: [TimeInterval] = [2, 4, 8, 16, 32, 32, 32, 32]
                 return KinUtil.attempt(retryIntervals: intervals,
                                        closure: { attemptNumber -> Promise<Void> in
-                    let p = KinUtil.Promise<Void>()
-                    logVerbose("attempt to get spend order with !pending state (and result): (\(attemptNumber)/\(intervals.count + 1))")
-                    var pending = true
-                    core.network.dataAtPath("orders/\(order.id)")
-                        .then { data in
-                            core.data.read(Order.self,
-                                           with: data,
-                                           readBlock: { networkOrder in
-                                jwtConfirmation = (networkOrder.result as? JWTConfirmation)?.jwt
-                                let hasResult = jwtConfirmation != nil
-                                logVerbose("spend order \(networkOrder.id) status: \(networkOrder.orderStatus), result: \(hasResult ? "👍🏼" : "nil")")
-                                if (networkOrder.orderStatus != .pending && hasResult) || networkOrder.orderStatus == .failed {
-                                    pending = false
-                                }
-                            }).then {
-                                if pending {
-                                    if attemptNumber == 5 || attemptNumber == intervals.count + 1 {
-                                        logWarn("attempts reached \(attemptNumber)")
-                                        _ = core.data.changeObjects(of: Order.self,
-                                                                    changeBlock: { _, orders in
-                                            if let order = orders.first {
-                                                order.orderStatus = attemptNumber == 5 ? .delayed : .failed
-                                            }
-                                        }, with: NSPredicate(with: ["id":order.id]))
-                                    }
-                                    p.signal(OrderStatusError.orderStillPending)
-                                } else {
-                                    p.signal(())
-                                }
-                            }
-                    }
-                    return p
+                                        let p = KinUtil.Promise<Void>()
+                                        logVerbose("attempt to get spend order with !pending state (and result): (\(attemptNumber)/\(intervals.count + 1))")
+                                        var pending = true
+                                        core.network.dataAtPath("orders/\(order.id)")
+                                            .then { data in
+                                                core.data.read(Order.self,
+                                                               with: data,
+                                                               readBlock: { networkOrder in
+                                                                jwtConfirmation = (networkOrder.result as? JWTConfirmation)?.jwt
+                                                                let hasResult = jwtConfirmation != nil
+                                                                logVerbose("spend order \(networkOrder.id) status: \(networkOrder.orderStatus), result: \(hasResult ? "👍🏼" : "nil")")
+                                                                if (networkOrder.orderStatus != .pending && hasResult) || networkOrder.orderStatus == .failed {
+                                                                    pending = false
+                                                                }
+                                                }).then {
+                                                    if pending {
+                                                        if attemptNumber == 5 || attemptNumber == intervals.count + 1 {
+                                                            logWarn("attempts reached \(attemptNumber)")
+                                                            _ = core.data.changeObjects(of: Order.self,
+                                                                                        changeBlock: { _, orders in
+                                                                                            if let order = orders.first {
+                                                                                                order.orderStatus = attemptNumber == 5 ? .delayed : .failed
+                                                                                            }
+                                                            }, with: NSPredicate(with: ["id":order.id]))
+                                                        }
+                                                        p.signal(OrderStatusError.orderStillPending)
+                                                    } else {
+                                                        p.signal(())
+                                                    }
+                                                }
+                                        }
+                                        return p
                 }).then {
                     KinUtil.Promise<OpenOrder>().signal(order)
                 }
@@ -532,7 +531,6 @@ struct Flows {
                     Kin.track { try EarnOrderCreationFailed(errorReason: responseError.message ?? "\(responseError.code)", offerID: openOrder?.offer_id ?? "") }
                 }
                 Kin.track { try SpendOrderFailed(errorReason: "\(error)", isNative: true, offerID: openOrder?.offer_id ?? "", orderID: openOrder?.id ?? "") }
-                core.blockchain.stopWatchingForNewPayments()
                 _ = core.blockchain.balance()
                 if let order = openOrder, canCancelOrder {
                     core.network.delete("orders/\(order.id)")
@@ -570,34 +568,34 @@ struct Flows {
                                                         if (networkOrder.orderStatus != .pending && hasResult) || networkOrder.orderStatus == .failed {
                                                             pending = false
                                                         }
-                                                    }.then {
-                                                        if pending {
-                                                            if attemptNumber == 5 || attemptNumber == intervals.count + 1 {
-                                                                logWarn("attempts reached \(attemptNumber)")
-                                                                _ = core.data.changeObjects(of: Order.self,
-                                                                                            changeBlock: { _, orders in
-                                                                                                if let order = orders.first {
-                                                                                                    order.orderStatus = attemptNumber == 5 ? .delayed : .failed
-                                                                                                }
-                                                                }, with: NSPredicate(with: ["id":order]))
+                                                        }.then {
+                                                            if pending {
+                                                                if attemptNumber == 5 || attemptNumber == intervals.count + 1 {
+                                                                    logWarn("attempts reached \(attemptNumber)")
+                                                                    _ = core.data.changeObjects(of: Order.self,
+                                                                                                changeBlock: { _, orders in
+                                                                                                    if let order = orders.first {
+                                                                                                        order.orderStatus = attemptNumber == 5 ? .delayed : .failed
+                                                                                                    }
+                                                                    }, with: NSPredicate(with: ["id":order]))
+                                                                }
+                                                                p.signal(OrderStatusError.orderStillPending)
+                                                            } else {
+                                                                p.signal(())
                                                             }
-                                                            p.signal(OrderStatusError.orderStillPending)
-                                                        } else {
-                                                            p.signal(())
-                                                        }
                                                     }
-                                            }.error { error in
-                                                 p.signal(())
+                                                }.error { error in
+                                                    p.signal(())
                                             }
-                        return p
+                                            return p
                     }).then {
                         if let jwt = jwtConfirmation {
                             jwtPromise.signal(jwt)
                         } else  {
                             jwtPromise.signal(KinEcosystemError.service(.timeout, nil))
                         }
-                    }.error { error in
-                        jwtPromise.signal(error)
+                        }.error { error in
+                            jwtPromise.signal(error)
                     }
                 } else {
                     openOrder = nil
@@ -618,10 +616,10 @@ struct Flows {
                         if let order = openOrder {
                             _ = core.data.changeObjects(of: Order.self,
                                                         changeBlock: { _, orders in
-                                if let  completedOrder = orders.first,
-                                    completedOrder.orderStatus != .failed {
-                                    completedOrder.orderStatus = .completed
-                                }
+                                                            if let  completedOrder = orders.first,
+                                                                completedOrder.orderStatus != .failed {
+                                                                completedOrder.orderStatus = .completed
+                                                            }
                             }, with: NSPredicate(with: ["id": order.id]))
                         }
                         openOrder = nil
@@ -681,10 +679,18 @@ struct Flows {
                         return POFlowPromise().signal((memo, order))
                 }
             }.then { memo, order -> POFlowPromise in
-                return core.blockchain.waitForNewPayment(with: memo)
+                let p = POFlowPromise()
+                core.blockchain.waitForNewPayment(with: memo, timeout: 15.0)
                     .then { txHash in
-                        POFlowPromise().signal((memo, order))
+                        Kin.track { try EarnOrderPaymentConfirmed(orderID: order.id, transactionID: txHash) }
+                    } .error({ (_) in
+                        //in case of timeout, relay on server order verfication
+                        logVerbose("waitForNewPayment timeout, waiting for order confirmation.")
+                    })
+                    .finally {
+                        p.signal((memo, order))
                 }
+                return p
             }.then { memo, order -> KinUtil.Promise<OpenOrder> in
                 core.blockchain.stopWatchingForNewPayments(with: memo)
                 let intervals: [TimeInterval] = [2, 4, 8, 16, 32, 32, 32, 32]
@@ -728,6 +734,8 @@ struct Flows {
                 
             }.then { order in
                 Kin.track { try EarnOrderCompleted(kinAmount: Double(order.amount), offerID: order.offer_id, offerType: .external, orderID: order.id) }
+                //update balance after order completed
+                _ = core.blockchain.balance()
                 if let confirmation = jwtConfirmation {
                     jwtPromise.signal(confirmation)
                 } else {

--- a/KinEcosystem/Promises/Flows.swift
+++ b/KinEcosystem/Promises/Flows.swift
@@ -241,7 +241,6 @@ struct Flows {
                     return SDOPFlowPromise().signal(KinEcosystemError.client(.internalInconsistency, nil))
                 }
                 let memo = PaymentMemoIdentifier(appId: appId, id: order.id)
-                try core.blockchain.startWatchingForNewPayments(with: memo)
                 return core.network.dataAtPath("orders/\(order.id)",
                     method: .post)
                     .then { data in
@@ -278,7 +277,6 @@ struct Flows {
                 }
             }.then { memo, order -> KinUtil.Promise<OpenOrder> in
                 _ = core.blockchain.balance();
-                core.blockchain.stopWatchingForNewPayments(with: memo)
                 let intervals: [TimeInterval] = [2, 4, 8, 16, 32, 32, 32, 32]
                 return attempt(retryIntervals: intervals,
                                closure: { attemptNumber -> Promise<Void> in
@@ -326,7 +324,6 @@ struct Flows {
                     Kin.track { try SpendOrderCancelled(offerID: offerId, orderID: openOrder?.id ?? "") }
                 } else {
                     logError("\(error)")
-                    core.blockchain.stopWatchingForNewPayments()
                 }
                 if case KinError.insufficientFunds = error {
                     Kin.track { try SpendTransactionBroadcastToBlockchainFailed(errorReason: "\(error)", offerID: offerId, orderID: openOrder?.id ?? "") }


### PR DESCRIPTION
#### Main purpose:
Deal with 2 bugs:
* balance not updated correctly.
* order reported failure while actually succeeded, happened due to a timeout (after a very long time of 300 sec) on payment watch that failed the entire process (while tx was sent successfully from server side)
#### Technical description:
* remove listening to payment when doing a spend order, as we send transaction to the blockchain
success of sendTransaction means blockchain confirmation for this tx.
* earn orders - reduce timeout of payment watch to 15 sec, in case of failure continue and relay on server's order confirmation.
* do not relay only on payment watch for updating balance, update explicitly, earn - on getting order
confirmation from server, spend - after a successful transaction.
