### PR TITLE
add more condition to reset data

### DIFF
--- a/KinDevPlatform/KinDevPlatform/Core/Kin.swift
+++ b/KinDevPlatform/KinDevPlatform/Core/Kin.swift
@@ -143,7 +143,7 @@ public class Kin: NSObject {
         let lastUser = UserDefaults.standard.string(forKey: KinPreferenceKey.lastSignedInUser.rawValue)
         let lastEnvironmentName = UserDefaults.standard.string(forKey: KinPreferenceKey.lastEnvironment.rawValue)
 
-        let isNewUser = lastUser != nil && lastUser != userId
+        let isNewUser = (lastUser != nil && lastUser != userId) || lastUser == nil
         let isNewEnvironmentName = lastEnvironmentName != nil && lastEnvironmentName != environment.name
 
         if isNewUser || isNewEnvironmentName {


### PR DESCRIPTION
* Main purpose: 
ios Kin SDK 1.0.8 migration bug
 
* Technical description: 
has a delete-and-reinstall bug, where a new user sees the balance from an old user’s wallet on the same device

* Dilemmas you faced with? https://kindeveloperprogram.slack.com/archives/GFS1JQUQK/p1555564623028600

* Tests: 
User1 and user2 are using on the same device
    1) remove the current app which has logged by user1 (kin2 wallet, balance >0)
    2) mode = 3
    3) remove app and user2 upgrades to an app with 1.0.8 SDK
    4) upgrade should happen automatically, wallet gets a public wallet and balance from the user1 wallet)

* Documentation (Source/readme.md)